### PR TITLE
22 zustand 스토어 값이 초기화 되지 않는 문제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,6 @@ yarn-error.log*
 .vercel
 
 # typescript
+.idea
 *.tsbuildinfo
+/.idea/git_toolbox_prj.xml

--- a/src/features/admin_document/business/hooks/editor.hooks.ts
+++ b/src/features/admin_document/business/hooks/editor.hooks.ts
@@ -17,7 +17,7 @@ export const useEditorHook = () => {
   const documentId = searchParams.get('id');
   const type = searchParams.get('type');
 
-  const { model, change } = useEditorStore(state => state);
+  const { model, change, initializeState } = useEditorStore(state => state);
 
   const { mutate } = api.document.saveContent.useMutation();
   const { data: document } = api.document.getOneDocument.useQuery({
@@ -40,6 +40,7 @@ export const useEditorHook = () => {
       toast({
         title: 'Save...',
       });
+      void initializeState();
       mutate(
         { model, type, documentId: documentId === null ? null : +documentId },
         {
@@ -50,6 +51,7 @@ export const useEditorHook = () => {
               });
               return;
             }
+
             const { document_id } = document;
             toast({
               title: 'Save successfully',

--- a/src/features/admin_document/stores/useEditorStore.ts
+++ b/src/features/admin_document/stores/useEditorStore.ts
@@ -3,9 +3,11 @@ import { create } from 'zustand';
 interface EditorState {
   model: string;
   change: (model: string) => void;
+  initializeState: () => void;
 }
 
 export const useEditorStore = create<EditorState>()(set => ({
   model: '',
   change: (value: string) => set(_ => ({ model: value })),
+  initializeState: () => set(_ => ({ model: '' })),
 }));


### PR DESCRIPTION
어드민 페이지에서 문서 생성 완료 후 다시 생성하려 할 때 콘텐츠가 초기화 되지 않는 문제가 있었음.

- mutate의 onSuccess 메서드에 initializeState를 호출하도록 하여 초기화.